### PR TITLE
test: add tests for required finders fee bps and ensuring a valid update on newly set offers

### DIFF
--- a/contracts/test/modules/Offers/V1/Offers.t.sol
+++ b/contracts/test/modules/Offers/V1/Offers.t.sol
@@ -205,6 +205,20 @@ contract OffersV1Test is DSTest {
         vm.stopPrank();
     }
 
+    function testRevert_CannotUpdateOfferWithPreviousAmount() public {
+        vm.startPrank(address(maker));
+
+        offers.createOffer{value: 1 ether}(address(token), 0, address(0), 1 ether, 1000);
+
+        vm.warp(1 hours);
+
+        vm.expectRevert("setOfferAmount invalid _amount");
+
+        offers.setOfferAmount{value: 1 ether}(address(token), 0, 1, address(0), 1 ether);
+
+        vm.stopPrank();
+    }
+
     function testRevert_CannotUpdateInactiveOffer() public {
         vm.prank(address(maker));
         offers.createOffer{value: 1 ether}(address(token), 0, address(0), 1 ether, 1000);

--- a/contracts/test/modules/Offers/V1/Offers.t.sol
+++ b/contracts/test/modules/Offers/V1/Offers.t.sol
@@ -110,6 +110,11 @@ contract OffersV1Test is DSTest {
         offers.createOffer(address(token), 0, address(0), 1 ether, 1000);
     }
 
+    function testFail_CannotCreateOfferWithInvalidFindersFeeBps() public {
+        vm.prank(address(maker));
+        offers.createOffer(address(token), 0, address(0), 1 ether, 10001);
+    }
+
     /// ------------ SET NFT OFFER ------------ ///
 
     function test_IncreaseETHOffer() public {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Towards https://github.com/ourzora/v3/pull/126

This adds missing tests for the Offers v1.0 contract.

## Motivation and Context

<!--- Why is this module required? What problem does it solve? -->

These changes add to the work in https://github.com/ourzora/v3/pull/126 by including tests for required finders fee bps and ensuring a valid update on newly set offers. I noticed a handful of other tests were written to check for these cases (like [checking that only the seller can update an offer](https://github.com/ourzora/v3/pull/126/files#diff-2c617a91bb05064734aba39f2e1c9eeedccdcf71c9b3be3f4bc8c6405c6beecaR185-R191) or [handling the case where an incoming transfer message value is less than the expected amount](https://github.com/ourzora/v3/pull/126/files#diff-2c617a91bb05064734aba39f2e1c9eeedccdcf71c9b3be3f4bc8c6405c6beecaR193-R201)).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran `yarn test` and they passed on my machine. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] The module includes tests written for Foundry
- [x] The module is documented with [NATSPEC](https://docs.soliditylang.org/en/v0.5.10/natspec-format.html)
- [x] The documentation includes [UML Diagrams](https://plantuml.com/ascii-art) for external and public functions
- [x] The module is a [Hyperstructure](https://www.jacob.energy/hyperstructures.html)
