### PR TITLE
Fix: replace USE_ALL_GAS_FLAG constant with OUTGOING_TRANSFER_GAS_LIMIT

### DIFF
--- a/contracts/modules/ReserveAuction/V1/ReserveAuctionV1.sol
+++ b/contracts/modules/ReserveAuction/V1/ReserveAuctionV1.sol
@@ -14,6 +14,7 @@ import {ModuleNamingSupportV1} from "../../../common/ModuleNamingSupport/ModuleN
 /// @author tbtstl <t@zora.co>
 /// @notice This contract allows users to list and bid on ERC-721 tokens with timed reserve auctions
 contract ReserveAuctionV1 is ReentrancyGuard, UniversalExchangeEventV1, IncomingTransferSupportV1, FeePayoutSupportV1, ModuleNamingSupportV1 {
+    uint256 private constant OUTGOING_TRANSFER_GAS_LIMIT = 30000;
     /// @notice The minimum amount of time left in an auction after a new bid is created
     uint256 constant TIME_BUFFER = 15 minutes;
     /// @notice The minimum percentage difference between the last bid amount and the current bid.
@@ -395,7 +396,7 @@ contract ReserveAuctionV1 is ReentrancyGuard, UniversalExchangeEventV1, Incoming
 
             // Else refund previous bidder
         } else {
-            _handleOutgoingTransfer(auction.bidder, auction.amount, auction.currency, 30000);
+            _handleOutgoingTransfer(auction.bidder, auction.amount, auction.currency, OUTGOING_TRANSFER_GAS_LIMIT);
         }
 
         // Ensure incoming bid payment is valid and take custody
@@ -495,13 +496,13 @@ contract ReserveAuctionV1 is ReentrancyGuard, UniversalExchangeEventV1, Incoming
         // Payout optional finders fee
         if (auction.finder != address(0)) {
             uint256 finderFee = (remainingProfit * auction.findersFeeBps) / 10000;
-            _handleOutgoingTransfer(auction.finder, finderFee, auction.currency, 30000);
+            _handleOutgoingTransfer(auction.finder, finderFee, auction.currency, OUTGOING_TRANSFER_GAS_LIMIT);
 
             remainingProfit -= finderFee;
         }
 
         // Transfer remaining funds to seller
-        _handleOutgoingTransfer(auction.sellerFundsRecipient, remainingProfit, auction.currency, 30000);
+        _handleOutgoingTransfer(auction.sellerFundsRecipient, remainingProfit, auction.currency, OUTGOING_TRANSFER_GAS_LIMIT);
 
         // Transfer NFT to winning bidder
         IERC721(_tokenContract).transferFrom(address(this), auction.bidder, _tokenId);

--- a/contracts/modules/ReserveAuction/V1/ReserveAuctionV1.sol
+++ b/contracts/modules/ReserveAuction/V1/ReserveAuctionV1.sol
@@ -14,8 +14,6 @@ import {ModuleNamingSupportV1} from "../../../common/ModuleNamingSupport/ModuleN
 /// @author tbtstl <t@zora.co>
 /// @notice This contract allows users to list and bid on ERC-721 tokens with timed reserve auctions
 contract ReserveAuctionV1 is ReentrancyGuard, UniversalExchangeEventV1, IncomingTransferSupportV1, FeePayoutSupportV1, ModuleNamingSupportV1 {
-    /// @dev The indicator to pass all remaining gas when paying out royalties
-    uint256 private constant USE_ALL_GAS_FLAG = 0;
     /// @notice The minimum amount of time left in an auction after a new bid is created
     uint256 constant TIME_BUFFER = 15 minutes;
     /// @notice The minimum percentage difference between the last bid amount and the current bid.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Towards https://github.com/ourzora/v3/pull/122

This replaces the `USE_ALL_GAS_FLAG` constant with a new constant, `OUTGOING_TRANSFER_GAS_LIMIT`. 

## Motivation and Context

<!--- Why is this module required? What problem does it solve? -->

This addresses two points:

- `@tbtstl`'s  callout of an unused var (https://github.com/ourzora/v3/pull/122#discussion_r804800016)
- https://github.com/ourzora/v3/pull/122/commits/5511daf935f623b6f402926d2040c00f461ee9c6 introduced a new hardcoded gas limit on handling all outgoing transfers. This is moved into its own constant for changeability/readability/reusability for other modules.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

No tests since these are private constants.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] The module includes tests written for Foundry
- [x] The module is documented with [NATSPEC](https://docs.soliditylang.org/en/v0.5.10/natspec-format.html)
- [x] The documentation includes [UML Diagrams](https://plantuml.com/ascii-art) for external and public functions
- [x] The module is a [Hyperstructure](https://www.jacob.energy/hyperstructures.html)
