### PR TITLE
ZoraModuleManager.sol Gas Optimization

### DIFF
--- a/contracts/test/ZoraModuleManager.t.sol
+++ b/contracts/test/ZoraModuleManager.t.sol
@@ -88,7 +88,7 @@ contract ZoraModuleManagerTest is DSTest {
     function testRevert_ModuleAlreadyRegistered() public {
         registrar.registerModule(module);
 
-        vm.expectRevert("ZMM::registerModule module already registered");
+        vm.expectRevert("ZMM__registerModule_module_already_registered");
         registrar.registerModule(module);
     }
 
@@ -100,7 +100,7 @@ contract ZoraModuleManagerTest is DSTest {
     }
 
     function testRevert_CannotSetRegistrarToAddressZero() public {
-        vm.expectRevert("ZMM::setRegistrar must set registrar to non-zero address");
+        vm.expectRevert("ZMM__must_set_registrar_to_nonZero_address");
         registrar.setRegistrar(address(0));
     }
 }


### PR DESCRIPTION
## Description & Motivation and Context

Most of the Zora-V3 contracts are using `require` statements for reverting errors. Which is not a very gas-efficient way to revert errors. The `require` statements stores `Strings` which costs a lot of Gas (deploying + function Calling & Reverting). 
And as the protocol aims to be [Gas Efficient](https://docs.zora.co/docs/v3-overview#gas-efficient), Then it would be much better to not use `require` statements to revert the errors.
Instead, use `Custom Errors`. Which is a new solidity feature (introduced in 0.8.*)
Custom errors do the same thing but cost much less gas than the `require` statements.
For more info read [this](https://ethereum.stackexchange.com/questions/101782/requirecondition-message-vs-revert-with-a-custom-error-which-is-better-a)

## How has this been tested?

Firstly to show that, the `Custom Errors` lowers the deploying Costs I tested before & after deploying gas cost tests on Remix IDE. It's saving **199117 Gas**

Before:
![zoraModuleManagerRemixBefore](https://user-images.githubusercontent.com/99166851/185843666-6002a101-0a7d-409a-b1df-c317eadec776.JPG)

After:
![zoraModuleManagerRemixAfter](https://user-images.githubusercontent.com/99166851/185843673-59ca093b-9a9a-4c9c-8533-1dba7c0d6f65.JPG)

And after that, to get an estimate of how much function Calling Gasis saving I did before & after tests on VS Code using Foundry. 

Before:
![zoraModuleManagerBefore](https://user-images.githubusercontent.com/99166851/185844061-00484070-3cea-4d3b-bcb2-877537c68557.JPG)

After:
![zoraModuleManagerAfter](https://user-images.githubusercontent.com/99166851/185844068-9918e221-c1dd-4191-964f-efe416a37e41.JPG)

Even tho, 2 foundry tests are failing but we can see that `custom errors` are saving functions calling Gas As well.
And the 2 functions that are failing are just because they were not expecting those lines of errors.
Even tho, I changed the tests' revert text as well (similar to the expected error) but it's still failing don't know why, so please anyone from the Zora team pls guide me on what more changes I need to make.

## Checklist:

**My changes do not require any of the followings:**

- [x] The module includes tests written for Foundry
- [x] The module is documented with [NATSPEC](https://docs.soliditylang.org/en/v0.5.10/natspec-format.html)
- [x] The documentation includes [UML Diagrams](https://plantuml.com/ascii-art) for external and public functions
- [x] The module is a [Hyperstructure](https://www.jacob.energy/hyperstructures.html)

1 contract fixed of issue #177 :)
Thanks,
AB Dee.